### PR TITLE
Use azul/zulu upstream instead of maven

### DIFF
--- a/maven/3-jdk-8-alpine.Dockerfile
+++ b/maven/3-jdk-8-alpine.Dockerfile
@@ -1,9 +1,18 @@
-FROM maven:3-jdk-8-alpine
+FROM azul/zulu-openjdk-alpine:8
 
-RUN set -eux; \
+RUN set -ex; \
     apk add --no-cache \
-        git \
+      bash \
+      curl \
+      git \
+      procps \
+      wget \
     ; \
+    \
+    # Install Maven.
+    wget https://raw.githubusercontent.com/capralifecycle/buildtools-snippets/master/tools/maven-3/install.sh -O- | sh; \
+    mvn -version; \
+    \
     # Add a user with the UID that Jenkins will use during builds.
     # This solves issues for some builds that require the user to exist.
     adduser -D -u 1000 jenkins

--- a/maven/3-jdk-8-debian.Dockerfile
+++ b/maven/3-jdk-8-debian.Dockerfile
@@ -1,13 +1,20 @@
-FROM maven:3-jdk-8-slim
+FROM azul/zulu-openjdk-debian:8
 
 # procps added because of https://issues.jenkins-ci.org/browse/JENKINS-40101
-RUN set -eux; \
+RUN set -ex; \
     apt-get update; \
     apt-get install -y \
-      procps \
+      curl \
       git \
+      procps \
+      wget \
     ; \
     rm -rf /var/lib/apt/lists/*; \
+    \
+    # Install Maven.
+    wget https://raw.githubusercontent.com/capralifecycle/buildtools-snippets/master/tools/maven-3/install.sh -O- | sh; \
+    mvn -version; \
+    \
     # Add a user with the UID that Jenkins will use during builds.
     # This solves issues for some builds that require the user to exist.
     useradd -u 1000 jenkins


### PR DESCRIPTION
The maven upstream version we were using are no longer maintained.

We are already using azul/zulu for the Java 11 builds.